### PR TITLE
reset payloadlen for the message of TOPIC_TWO to fix JSON parse error

### DIFF
--- a/_cmake/sketch/temperature_mqtt.ino.cpp
+++ b/_cmake/sketch/temperature_mqtt.ino.cpp
@@ -196,6 +196,7 @@ main() {
 	    
 	    // Send JSON Object via MQTT
       pubmsg.payload = str_mqtt;
+      pubmsg.payloadlen = strlen(str_mqtt);
       
       // Publish TOPIC_ONE
       if ((rc = MQTTAsync_sendMessage(client, TOPIC_TWO, &pubmsg, &opts)) != MQTTASYNC_SUCCESS) {


### PR DESCRIPTION
This will cause JSON parse error when I try to get the data of humidity, add one line to fix this.